### PR TITLE
Fix role assignment

### DIFF
--- a/src/roles.ts
+++ b/src/roles.ts
@@ -45,6 +45,7 @@ export const sendRoleSelect = async (
   interaction: CommandInteraction<CacheType> | ButtonInteraction<CacheType>,
   type: OverarchingCategory
 ) => {
+  if (interaction.replied) return;
   if (!interaction.guildId)
     return interaction.reply({
       content: "Could not get guild information",


### PR DESCRIPTION
The error was `sendRoleSelect` being called multiple times and therefore the bot was 'replying' to the same interaction multiple times which raised an `InteractionAlreadyReplied` exception.